### PR TITLE
Add default placeholder image when creating items without images

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -146,6 +146,10 @@ router.post("/", auth.required, function(req, res, next) {
 
       var item = new Item(req.body.item);
 
+      if(!item.image){
+        item.image = "/placeholder.png";
+      }
+
       item.seller = user;
 
       return item.save().then(function() {


### PR DESCRIPTION
# Description

Fix creating items without images by adding a default placeholder image in the backend.